### PR TITLE
Reworked enter text and clear text to send events in correct order.

### DIFF
--- a/calabash/Classes/Recorder/LPTouchRecorder.h
+++ b/calabash/Classes/Recorder/LPTouchRecorder.h
@@ -47,8 +47,12 @@ typedef enum
 @property(assign, nonatomic) double startTouchTime;
 @property(strong, nonatomic) NSMutableArray *items;
 @property(strong, nonatomic) Class lastTouch;
+@property(nonatomic) BOOL textEntered;
+@property(strong, nonatomic) NSString *currentTextEntered;
+@property(strong, nonatomic) NSMutableDictionary *currentTextEvent;
 
 + (LPTouchRecorder *) sharedRecorder;
+- (void) shouldSendTextEntry;
 - (void) sendEvent:(id)event;
 - (void) viewWillDisappear:(id)viewController isAnimated:(bool)animated;
 - (NSArray *) Items;


### PR DESCRIPTION
Previously the DidEndEditingNotification was getting fired after tap events so if you had an enter text or clear text event and tapped another text field you would see the tap come in before the text entry events so this PR is to address that. The current approach is to store the entered text and to send the text entry if any other event is getting fired and then to clear the existing text for reuse.
